### PR TITLE
callouts with classes are now rendered correctly

### DIFF
--- a/src/inky.xsl
+++ b/src/inky.xsl
@@ -164,20 +164,10 @@
     </xsl:template>
 
     <xsl:template match="//callout">
-        <table class="">
+        <table class="callout">
             <xsl:copy-of select="@*[name()!='class']"/>
             <tr>
-                <th class="callout-inner"><xsl:apply-templates /></th>
-                <th class="expander"></th>
-            </tr>
-        </table>
-    </xsl:template>
-
-    <xsl:template match="//callout">
-        <table class="{normalize-space(concat(@class, ' callout'))}">
-            <xsl:copy-of select="@*[name()!='class']"/>
-            <tr>
-                <th class="callout-inner"><xsl:apply-templates /></th>
+                <th class="{normalize-space(concat('callout-inner ', @class))}"><xsl:apply-templates /></th>
                 <th class="expander"></th>
             </tr>
         </table>

--- a/tests/ComponentsTest.php
+++ b/tests/ComponentsTest.php
@@ -319,9 +319,9 @@ doc;
         <callout class="primary">Callout</callout>
 doc;
         $expected =<<<doc
-        <table class="primary callout">
+        <table class="callout">
             <tr>
-              <th class="callout-inner">Callout</th>
+              <th class="callout-inner primary">Callout</th>
               <th class="expander"></th>
             </tr>
         </table>


### PR DESCRIPTION
The current version of the callouts with classes is erroneous:

```html
<table class="primary callout">
  <tr>
    <th class="callout-inner">
      <p>foobar</p>
    </th>
    <th class="expander"></th>
  </tr>
</table>
```

According to https://foundation.zurb.com/emails/docs/callout.html, callouts with classes should produce the following html:

```xml
<callout class="primary">
  <p>foobar</p>
</callout>
```
produces
```html
<table class="callout">
  <tr>
    <th class="callout-inner primary">
      <p>foobar</p>
    </th>
    <th class="expander"></th>
  </tr>
</table>
```

This PR fixes this...

Nevertheless `callout` template was duplicated on the `inky.xsl`.