### PR TITLE
Add CI jobs for PHP 8 and PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '5.6', '7.1', '7.2', '7.3', '7.4' ]
+                php: [ '5.6', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
 
         steps:
             -   uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "ext-xsl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.21 || ^9.5.10"
     }
 }


### PR DESCRIPTION
This allows installing newer PHPUnit versions than 5.7, as PHPUnit 5 does not work on PHP 8. The testsuite was already compatible with them.