### PR TITLE
Clarify constants are from root namespace

### DIFF
--- a/src/pinky.php
+++ b/src/pinky.php
@@ -18,7 +18,7 @@ function createInkyProcessor()
     $centering = new DOMDocument();
     $centering->load(__DIR__ . "/inky-center.xsl");
 
-    $security = XSL_SECPREF_READ_FILE | XSL_SECPREF_READ_NETWORK | XSL_SECPREF_DEFAULT;
+    $security = \XSL_SECPREF_READ_FILE | \XSL_SECPREF_READ_NETWORK | \XSL_SECPREF_DEFAULT;
     $centerProcessor = new XSLTProcessor();
     $centerProcessor->setSecurityPrefs($security);
     $centerProcessor->importStylesheet($centering);


### PR DESCRIPTION
Hi there!

I got an error running Tests for my Application on PHP 8.1.4: `Error : Undefined constant "Pinky\XSL_SECPREF_READ_FILE"` . 
This PR fixes the error.

Cheers!