### PR TITLE
[FEATURE] Add data-href as button attribute

### DIFF
--- a/src/inky.xsl
+++ b/src/inky.xsl
@@ -104,7 +104,7 @@
 
     <xsl:template match="//button">
         <table class="{normalize-space(concat(@class, ' button'))}">
-            <xsl:copy-of select="@*[name()!='class' and name()!='href' and name()!='target']"/>
+            <xsl:copy-of select="@*[name()!='class' and name()!='href' and name()!='data-href' and name()!='target']"/>
             <tr>
                 <td>
                     <table>
@@ -116,6 +116,9 @@
                                             <a align="center" class="float-center">
                                                 <xsl:copy-of select="@target"/>
                                                 <xsl:copy-of select="@href"/>
+                                                <xsl:if test="@data-href">
+                                                    <xsl:attribute name="href"><xsl:value-of select="@data-href"/></xsl:attribute>
+                                                </xsl:if>
                                                 <xsl:apply-templates />
                                             </a>
                                         </center>
@@ -124,6 +127,9 @@
                                         <a>
                                             <xsl:copy-of select="@target"/>
                                             <xsl:copy-of select="@href"/>
+                                            <xsl:if test="@data-href">
+                                                <xsl:attribute name="href"><xsl:value-of select="@data-href"/></xsl:attribute>
+                                            </xsl:if>
                                             <xsl:apply-templates />
                                         </a>
                                     </xsl:otherwise>

--- a/tests/ComponentsTest.php
+++ b/tests/ComponentsTest.php
@@ -68,6 +68,11 @@ doc;
             <button href="http://zurb.com">Button</button>
         </center>
 doc;
+        $docWithDataHref =<<<doc
+        <center>
+            <button data-href="http://zurb.com">Button</button>
+        </center>
+doc;
         $expected =<<<doc
         <center>
             <table align="center" class="float-center button">
@@ -84,6 +89,7 @@ doc;
         </center>
 doc;
         $this->assertSameDocuments($doc, $expected);
+        $this->assertSameDocuments($docWithDataHref, $expected);
     }
 
     public function testCenterAppliesClassToMenuItems()
@@ -120,6 +126,9 @@ doc;
         $doc =<<<doc
         <button href="http://zurb.com">Button</button>
 doc;
+        $docWithDataHref =<<<doc
+        <button data-href="http://zurb.com">Button</button>
+doc;
         $expected =<<<doc
         <table class="button">
             <tr>
@@ -134,12 +143,16 @@ doc;
         </table>
 doc;
         $this->assertSameDocuments($doc, $expected);
+        $this->assertSameDocuments($docWithDataHref, $expected);
     }
 
     public function testCreateButtonWithTarget()
     {
         $doc =<<<doc
         <button href="http://zurb.com" target="_blank">Button</button>
+doc;
+        $docWithDataHref =<<<doc
+        <button data-href="http://zurb.com" target="_blank">Button</button>
 doc;
         $expected =<<<doc
         <table class="button">
@@ -155,6 +168,7 @@ doc;
         </table>
 doc;
         $this->assertSameDocuments($doc, $expected);
+        $this->assertSameDocuments($docWithDataHref, $expected);
     }
 
 
@@ -162,6 +176,9 @@ doc;
     {
         $doc =<<<doc
         <button class="small alert" href="http://zurb.com">Button</button>
+doc;
+        $docWithDataHref =<<<doc
+        <button class="small alert" data-href="http://zurb.com">Button</button>
 doc;
         $expected =<<<doc
         <table class="small alert button">
@@ -177,12 +194,16 @@ doc;
         </table>
 doc;
         $this->assertSameDocuments($doc, $expected);
+        $this->assertSameDocuments($docWithDataHref, $expected);
     }
 
     public function testCreateExpandedButton()
     {
         $doc =<<<doc
         <button class="expand" href="http://zurb.com">Button</button>
+doc;
+        $docWithDataHref =<<<doc
+        <button class="expand" data-href="http://zurb.com">Button</button>
 doc;
         $expected =<<<doc
         <table class="expand button">
@@ -201,6 +222,7 @@ doc;
         </table>
 doc;
         $this->assertSameDocuments($doc, $expected);
+        $this->assertSameDocuments($docWithDataHref, $expected);
     }
 
     public function testCreateMenuWithContent()


### PR DESCRIPTION
If using `<button> `with href attribute in templates they are checked by other software before the xsl mapping is executed, then the href attribute from the button tag will be removed. Then an `<a>` tag without an href attribute is generated.
We are using this inky Template in newsletter of a TYPO3 website. There is an html-sanitizer which removes that href attribute. Normally `href` is not an button attribute but `data-*` is no problem. The patch adds data-href attribute to the xsl mapping.