### PR TITLE
Supports PHP8.2, fix mb_convert_encoding usage deprecation

### DIFF
--- a/src/pinky.php
+++ b/src/pinky.php
@@ -112,7 +112,7 @@ function loadTemplateString($html)
 {
     $document = new DOMDocument('1.0', 'UTF-8');
     $internalErrors = libxml_use_internal_errors(true);
-    $document->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+    $document->loadHTML(htmlspecialchars_decode(htmlentities($html)));
     libxml_use_internal_errors($internalErrors);
     $document->formatOutput = true;
     return $document;


### PR DESCRIPTION
To fix this error with php8.2

```
mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity\/mb_decode_numericentity instead in \/srv\/vendor\/lorenzo\/pinky\/src\/pinky.php line 115
```