### PR TITLE
Fix the handling of Unicode characters

### DIFF
--- a/src/pinky.php
+++ b/src/pinky.php
@@ -112,7 +112,7 @@ function loadTemplateString($html)
 {
     $document = new DOMDocument('1.0', 'UTF-8');
     $internalErrors = libxml_use_internal_errors(true);
-    $document->loadHTML(htmlspecialchars_decode(htmlentities($html)));
+    $document->loadHTML(mb_encode_numericentity($html, [0x80, 0x10FFFF, 0, 0x1FFFFF], 'UTF-8'));
     libxml_use_internal_errors($internalErrors);
     $document->formatOutput = true;
     return $document;

--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -1,0 +1,34 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+use function Pinky\transformString;
+
+class EncodingTest extends TestCase
+{
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideStrings
+     */
+    public function testMultiByteContent($expected, $input)
+    {
+        $this->assertEquals($expected, trim(transformString($input)->saveHTML()));
+    }
+
+    public static function provideStrings()
+    {
+        yield [
+            '<html><body><p>ASCII only</p></body></html>',
+            'ASCII only',
+        ];
+        yield [
+            '<html><body><p>Twoje zam&oacute;wienie oczekuje na wp&#322;at&#281; zadatku &#127475;&#127473;</p></body></html>',
+            'Twoje zamówienie oczekuje na wpłatę zadatku 🇳🇱',
+        ];
+        yield [
+            '<html><body><p>&#1055;&#1088;&#1080;&#1074;&#1077;&#1090; &#1084;&#1080;&#1088;!</p></body></html>',
+            'Привет мир!',
+        ];
+    }
+}


### PR DESCRIPTION
Closes #28 

`htmlspecialchars_decode(htmlentities($html))` is *not* actually a replacement for `mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8')`. However, there was no test covering that logic with actual Unicode characters so it was not caught during the work on 1.0.8.

The new logic is taken from https://github.com/tijsverkoyen/CssToInlineStyles/blob/c42125b83a4fa63b187fdf29f9c93cb7733da30c/src/CssToInlineStyles.php#L116 where it has been tested to be valid. New tests are added to cover this.